### PR TITLE
Always return versions as strings

### DIFF
--- a/lib/fastlane/plugin/release_actions/actions/calculate_next_canary_version.rb
+++ b/lib/fastlane/plugin/release_actions/actions/calculate_next_canary_version.rb
@@ -9,10 +9,12 @@ module Fastlane
         version = Version.new(Git.last_version)
 
         if version.prerelease?
-          version.bump_prerelease!
+          version = version.bump_prerelease!
         else
-          version.bump_patch!.prerelease!('unstable')
+          version = version.bump_patch!.prerelease!('unstable')
         end
+
+        version.to_s
       end
 
       def self.description

--- a/lib/fastlane/plugin/release_actions/actions/calculate_next_release_version.rb
+++ b/lib/fastlane/plugin/release_actions/actions/calculate_next_release_version.rb
@@ -17,7 +17,7 @@ module Fastlane
           UI.crash!('No commits found since last release')
         end
 
-        [bump_version(version, commits), commits]
+        [bump_version(version, commits).to_s, commits]
       end
 
       def self.bump_version(version, commits)


### PR DESCRIPTION
Within lanes we always use versions as strings given we do not need to
compare versions yet. To make this easier, always return a string
instead of a full-fledged Version object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
