### PR TITLE
Add set_key_value action

### DIFF
--- a/lib/fastlane/plugin/release_actions/actions/set_constant_value.rb
+++ b/lib/fastlane/plugin/release_actions/actions/set_constant_value.rb
@@ -1,0 +1,69 @@
+module Fastlane
+  module Actions
+    class SetConstantValueAction < Action
+      def self.run(params)
+        podspec = params[:podspec]
+        constant = params[:constant]
+        value = params[:value]
+        
+        podspec_contents = File.read(podspec)
+
+        CONSTANT_VERSION = /(?<=#{constant})(\s*=\s*["'].*)/
+  
+        if !podspec_contents.match(CONSTANT_VERSION)
+          UI.error("#{constant} not present or doesn't have an explicit value in #{podspec}")
+          return
+        end
+
+        new_value = " = '#{value}'"
+        
+        podspec_new_contents = podspec_contents.gsub(CONSTANT_VERSION, new_value)
+
+        File.open(podspec, "w") { |file| file.puts podspec_new_contents }
+        UI.success("Successfully modified #{constant} to value #{value} in #{podspec}")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'This action will modify the value of the passed in constant'
+      end
+
+      def self.available_options
+        [
+            FastlaneCore::ConfigItem.new(
+                key: :podspec,
+                env_name: 'PODSPEC_PATH',
+                description: 'The path of the file you wish to modify',
+                optional: false,
+                type: String
+            ),
+            FastlaneCore::ConfigItem.new(
+                key: :constant,
+                env_name: 'CONSTANT_NAME',
+                description: 'The constant you wish to modify',
+                optional: false,
+                type: String
+            ),
+            FastlaneCore::ConfigItem.new(
+                key: :value,
+                env_name: 'CONSTANT_VALUE',
+                description: 'The new value to assign to the constant',
+                optional: false,
+                type: String
+            )
+        ]
+      end
+
+      def self.authors
+        ['John Pignata', 'Ivan Artemiev']
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/release_actions/actions/set_constant_value.rb
+++ b/lib/fastlane/plugin/release_actions/actions/set_constant_value.rb
@@ -22,10 +22,6 @@ module Fastlane
         UI.success("Successfully modified #{constant} to value #{value} in #{file}")
       end
 
-      #####################################################
-      # @!group Documentation
-      #####################################################
-
       def self.description
         'This action will modify the value of the passed in constant'
       end

--- a/lib/fastlane/plugin/release_actions/actions/set_constant_value.rb
+++ b/lib/fastlane/plugin/release_actions/actions/set_constant_value.rb
@@ -2,25 +2,25 @@ module Fastlane
   module Actions
     class SetConstantValueAction < Action
       def self.run(params)
-        podspec = params[:podspec]
+        file = params[:file]
         constant = params[:constant]
         value = params[:value]
         
-        podspec_contents = File.read(podspec)
+        file_contents = File.read(file)
 
         CONSTANT_VERSION = /(?<=#{constant})(\s*=\s*["'].*)/
   
-        if !podspec_contents.match(CONSTANT_VERSION)
-          UI.error("#{constant} not present or doesn't have an explicit value in #{podspec}")
+        if !file_contents.match(CONSTANT_VERSION)
+          UI.error("#{constant} not present or doesn't have an explicit value in #{file}")
           return
         end
 
         new_value = " = '#{value}'"
         
-        podspec_new_contents = podspec_contents.gsub(CONSTANT_VERSION, new_value)
+        file_contents = file_contents.gsub(CONSTANT_VERSION, new_value)
 
-        File.open(podspec, "w") { |file| file.puts podspec_new_contents }
-        UI.success("Successfully modified #{constant} to value #{value} in #{podspec}")
+        File.open(file, "w") { |file| file.puts file_contents }
+        UI.success("Successfully modified #{constant} to value #{value} in #{file}")
       end
 
       #####################################################
@@ -34,8 +34,8 @@ module Fastlane
       def self.available_options
         [
             FastlaneCore::ConfigItem.new(
-                key: :podspec,
-                env_name: 'PODSPEC_PATH',
+                key: :file,
+                env_name: 'FILE_PATH',
                 description: 'The path of the file you wish to modify',
                 optional: false,
                 type: String

--- a/lib/fastlane/plugin/release_actions/actions/set_constant_value.rb
+++ b/lib/fastlane/plugin/release_actions/actions/set_constant_value.rb
@@ -3,23 +3,23 @@ module Fastlane
     class SetConstantValueAction < Action
       def self.run(params)
         file = params[:file]
-        constant = params[:constant]
+        key = params[:key]
         value = params[:value]
 
-        regex_constant_version = /(?<=#{constant})(\s*=\s*["'].*)/
+        regex_key = /(?<=#{key})(\s*=\s*["'].*)/
         file_contents = File.read(file)
 
-        unless file_contents.match(regex_constant_version)
+        unless file_contents.match(regex_key)
           UI.error("#{constant} not present or doesn't have an explicit value in #{file}")
           return
         end
 
         new_value = " = '#{value}'"
 
-        file_contents = file_contents.gsub(regex_constant_version, new_value)
+        file_contents = file_contents.gsub(regex_key, new_value)
 
         File.open(file, "w") { |f| f.puts(file_contents) }
-        UI.success("Successfully modified #{constant} to value #{value} in #{file}")
+        UI.success("Successfully modified #{key} to value #{value} in #{file}")
       end
 
       def self.description
@@ -36,9 +36,9 @@ module Fastlane
             type: String
           ),
           FastlaneCore::ConfigItem.new(
-            key: :constant,
-            env_name: 'CONSTANT_NAME',
-            description: 'The constant you wish to modify',
+            key: :key,
+            env_name: 'KEY_NAME',
+            description: 'The key of the value you wish to modify',
             optional: false,
             type: String
           ),

--- a/lib/fastlane/plugin/release_actions/actions/set_constant_value.rb
+++ b/lib/fastlane/plugin/release_actions/actions/set_constant_value.rb
@@ -5,21 +5,20 @@ module Fastlane
         file = params[:file]
         constant = params[:constant]
         value = params[:value]
-        
+
+        regex_constant_version = /(?<=#{constant})(\s*=\s*["'].*)/
         file_contents = File.read(file)
 
-        CONSTANT_VERSION = /(?<=#{constant})(\s*=\s*["'].*)/
-  
-        if !file_contents.match(CONSTANT_VERSION)
+        unless file_contents.match(regex_constant_version)
           UI.error("#{constant} not present or doesn't have an explicit value in #{file}")
           return
         end
 
         new_value = " = '#{value}'"
-        
-        file_contents = file_contents.gsub(CONSTANT_VERSION, new_value)
 
-        File.open(file, "w") { |file| file.puts file_contents }
+        file_contents = file_contents.gsub(regex_constant_version, new_value)
+
+        File.open(file, "w") { |f| f.puts(file_contents) }
         UI.success("Successfully modified #{constant} to value #{value} in #{file}")
       end
 
@@ -33,27 +32,27 @@ module Fastlane
 
       def self.available_options
         [
-            FastlaneCore::ConfigItem.new(
-                key: :file,
-                env_name: 'FILE_PATH',
-                description: 'The path of the file you wish to modify',
-                optional: false,
-                type: String
-            ),
-            FastlaneCore::ConfigItem.new(
-                key: :constant,
-                env_name: 'CONSTANT_NAME',
-                description: 'The constant you wish to modify',
-                optional: false,
-                type: String
-            ),
-            FastlaneCore::ConfigItem.new(
-                key: :value,
-                env_name: 'CONSTANT_VALUE',
-                description: 'The new value to assign to the constant',
-                optional: false,
-                type: String
-            )
+          FastlaneCore::ConfigItem.new(
+            key: :file,
+            env_name: 'FILE_PATH',
+            description: 'The path of the file you wish to modify',
+            optional: false,
+            type: String
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :constant,
+            env_name: 'CONSTANT_NAME',
+            description: 'The constant you wish to modify',
+            optional: false,
+            type: String
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :value,
+            env_name: 'CONSTANT_VALUE',
+            description: 'The new value to assign to the constant',
+            optional: false,
+            type: String
+          )
         ]
       end
 

--- a/lib/fastlane/plugin/release_actions/actions/set_key_value.rb
+++ b/lib/fastlane/plugin/release_actions/actions/set_key_value.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Actions
-    class SetConstantValueAction < Action
+    class SetKeyValueAction < Action
       def self.run(params)
         file = params[:file]
         key = params[:key]
@@ -10,7 +10,7 @@ module Fastlane
         file_contents = File.read(file)
 
         unless file_contents.match(regex_key)
-          UI.error("#{constant} not present or doesn't have an explicit value in #{file}")
+          UI.error("#{key} not present or doesn't have an explicit value in #{file}")
           return
         end
 
@@ -23,7 +23,7 @@ module Fastlane
       end
 
       def self.description
-        'This action will modify the value of the passed in constant'
+        'This action will modify the value of the passed in key'
       end
 
       def self.available_options
@@ -44,8 +44,8 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :value,
-            env_name: 'CONSTANT_VALUE',
-            description: 'The new value to assign to the constant',
+            env_name: 'KEY_VALUE',
+            description: 'The new value to assign to the key',
             optional: false,
             type: String
           )


### PR DESCRIPTION
*Issue #, if available:*

Usage: 
```ruby
set_key_value(file: 'somefile.rb', key: 'VERSION', value: '1.0.0')
```
I had this as a separate action. I think it makes sense to keep it in this project. 




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
